### PR TITLE
Cloud ux improvements

### DIFF
--- a/source/TwainDirect.App/FormSelect.cs
+++ b/source/TwainDirect.App/FormSelect.cs
@@ -134,8 +134,8 @@ namespace TwainDirect.App
                     (
                         new[] {
                             s.Name,
+                            s.Id,
                             s.Description,
-                            s.Manufacturer,
                             CloudManager.GetScannerCloudUrl(s),
                             "(no ip)"
                         }

--- a/source/TwainDirect.Scanner/FormMain.cs
+++ b/source/TwainDirect.Scanner/FormMain.cs
@@ -40,7 +40,9 @@ using System.Globalization;
 using System.IO;
 using System.Resources;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
+using TwainDirect.Scanner.Storage;
 using TwainDirect.Support;
 
 namespace TwainDirect.Scanner
@@ -149,7 +151,7 @@ namespace TwainDirect.Scanner
             }
 
             // Instantiate our setup object...
-            m_formsetup = new FormSetup(this, m_resourcemanager, blConfirmScan);
+            m_formsetup = new FormSetup(this, m_resourcemanager, m_scanner, blConfirmScan);
 
             // If we don't have any devices, then don't let the user select
             // the start button...
@@ -222,7 +224,7 @@ namespace TwainDirect.Scanner
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
-        public async void RegisterCloud()
+        public async Task RegisterCloud()
         {
             /*
             string szCloudSqlite = Path.Combine(Config.Get("writeFolder", ""), "cloud.sqlite");

--- a/source/TwainDirect.Scanner/FormSetup.Designer.cs
+++ b/source/TwainDirect.Scanner/FormSetup.Designer.cs
@@ -209,6 +209,7 @@
             this.m_CloudDevicesComboBox.Name = "m_CloudDevicesComboBox";
             this.m_CloudDevicesComboBox.Size = new System.Drawing.Size(375, 21);
             this.m_CloudDevicesComboBox.TabIndex = 82;
+            this.m_CloudDevicesComboBox.DropDown += new System.EventHandler(this.m_CloudDevicesComboBox_DropDown);
             this.m_CloudDevicesComboBox.SelectedIndexChanged += new System.EventHandler(this.m_CloudDevicesComboBox_SelectedIndexChanged);
             // 
             // FormSetup

--- a/source/TwainDirect.Scanner/FormSetup.Designer.cs
+++ b/source/TwainDirect.Scanner/FormSetup.Designer.cs
@@ -42,12 +42,14 @@
             this.m_textboxCurrentNote = new System.Windows.Forms.TextBox();
             this.m_labelCurrentNote = new System.Windows.Forms.Label();
             this.m_buttonManageCloud = new System.Windows.Forms.Button();
+            this.m_RegisteredDeviceLabel = new System.Windows.Forms.Label();
+            this.m_CloudDevicesComboBox = new System.Windows.Forms.ComboBox();
             this.SuspendLayout();
             // 
             // m_checkboxRunOnLogin
             // 
             this.m_checkboxRunOnLogin.AutoSize = true;
-            this.m_checkboxRunOnLogin.Location = new System.Drawing.Point(12, 250);
+            this.m_checkboxRunOnLogin.Location = new System.Drawing.Point(12, 283);
             this.m_checkboxRunOnLogin.Name = "m_checkboxRunOnLogin";
             this.m_checkboxRunOnLogin.Size = new System.Drawing.Size(187, 17);
             this.m_checkboxRunOnLogin.TabIndex = 70;
@@ -118,7 +120,7 @@
             // m_checkboxAdvertise
             // 
             this.m_checkboxAdvertise.AutoSize = true;
-            this.m_checkboxAdvertise.Location = new System.Drawing.Point(12, 273);
+            this.m_checkboxAdvertise.Location = new System.Drawing.Point(12, 306);
             this.m_checkboxAdvertise.Name = "m_checkboxAdvertise";
             this.m_checkboxAdvertise.Size = new System.Drawing.Size(360, 17);
             this.m_checkboxAdvertise.TabIndex = 74;
@@ -129,7 +131,7 @@
             // m_checkboxConfirmation
             // 
             this.m_checkboxConfirmation.AutoSize = true;
-            this.m_checkboxConfirmation.Location = new System.Drawing.Point(12, 296);
+            this.m_checkboxConfirmation.Location = new System.Drawing.Point(12, 329);
             this.m_checkboxConfirmation.Name = "m_checkboxConfirmation";
             this.m_checkboxConfirmation.Size = new System.Drawing.Size(237, 17);
             this.m_checkboxConfirmation.TabIndex = 75;
@@ -148,6 +150,8 @@
             // 
             // m_textboxCurrentDriver
             // 
+            this.m_textboxCurrentDriver.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.m_textboxCurrentDriver.BackColor = System.Drawing.SystemColors.Window;
             this.m_textboxCurrentDriver.Location = new System.Drawing.Point(91, 29);
             this.m_textboxCurrentDriver.Name = "m_textboxCurrentDriver";
@@ -157,6 +161,8 @@
             // 
             // m_textboxCurrentNote
             // 
+            this.m_textboxCurrentNote.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.m_textboxCurrentNote.BackColor = System.Drawing.SystemColors.Window;
             this.m_textboxCurrentNote.Location = new System.Drawing.Point(91, 55);
             this.m_textboxCurrentNote.Name = "m_textboxCurrentNote";
@@ -184,12 +190,35 @@
             this.m_buttonManageCloud.UseVisualStyleBackColor = true;
             this.m_buttonManageCloud.Click += new System.EventHandler(this.m_buttonManageCloud_Click);
             // 
+            // m_RegisteredDeviceLabel
+            // 
+            this.m_RegisteredDeviceLabel.AutoSize = true;
+            this.m_RegisteredDeviceLabel.Location = new System.Drawing.Point(46, 239);
+            this.m_RegisteredDeviceLabel.Name = "m_RegisteredDeviceLabel";
+            this.m_RegisteredDeviceLabel.Size = new System.Drawing.Size(111, 13);
+            this.m_RegisteredDeviceLabel.TabIndex = 81;
+            this.m_RegisteredDeviceLabel.Text = "Current Cloud Device:";
+            // 
+            // m_CloudDevicesComboBox
+            // 
+            this.m_CloudDevicesComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.m_CloudDevicesComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.m_CloudDevicesComboBox.FormattingEnabled = true;
+            this.m_CloudDevicesComboBox.Location = new System.Drawing.Point(163, 236);
+            this.m_CloudDevicesComboBox.Name = "m_CloudDevicesComboBox";
+            this.m_CloudDevicesComboBox.Size = new System.Drawing.Size(375, 21);
+            this.m_CloudDevicesComboBox.TabIndex = 82;
+            this.m_CloudDevicesComboBox.SelectedIndexChanged += new System.EventHandler(this.m_CloudDevicesComboBox_SelectedIndexChanged);
+            // 
             // FormSetup
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Window;
-            this.ClientSize = new System.Drawing.Size(550, 328);
+            this.ClientSize = new System.Drawing.Size(550, 356);
+            this.Controls.Add(this.m_CloudDevicesComboBox);
+            this.Controls.Add(this.m_RegisteredDeviceLabel);
             this.Controls.Add(this.m_buttonManageCloud);
             this.Controls.Add(this.m_textboxCurrentNote);
             this.Controls.Add(this.m_labelCurrentNote);
@@ -227,5 +256,7 @@
         private System.Windows.Forms.TextBox m_textboxCurrentNote;
         private System.Windows.Forms.Label m_labelCurrentNote;
         private System.Windows.Forms.Button m_buttonManageCloud;
+        private System.Windows.Forms.Label m_RegisteredDeviceLabel;
+        private System.Windows.Forms.ComboBox m_CloudDevicesComboBox;
     }
 }

--- a/source/TwainDirect.Scanner/FormSetup.cs
+++ b/source/TwainDirect.Scanner/FormSetup.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Win32;
 using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Resources;
@@ -246,6 +247,20 @@ namespace TwainDirect.Scanner
         private void m_CloudDevicesComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             m_scanner.SetCurrentCloudScanner(m_CloudDevicesComboBox.SelectedItem as CloudScanner);
+        }
+
+        private void m_CloudDevicesComboBox_DropDown(object sender, EventArgs e)
+        {
+            var comboBox = (ComboBox)sender;
+            var width = comboBox.DropDownWidth;
+            var font = comboBox.Font;
+
+            var vertScrollBarWidth = comboBox.Items.Count > comboBox.MaxDropDownItems ? SystemInformation.VerticalScrollBarWidth : 0;
+            var itemsList = comboBox.Items.Cast<object>().Select(item => item.ToString());
+
+            width = itemsList.Select(s => TextRenderer.MeasureText(s, font).Width + vertScrollBarWidth).Concat(new[] { width }).Max();
+
+            comboBox.DropDownWidth = width;
         }
 
         /// <summary>


### PR DESCRIPTION
- Select Scanner dialog shows cloud scanner ID and Note
- Scanner Setup dialog shows all registered cloud scanners and remembers the current one. This should remove ambiguity after registration of new scanners.