### PR TITLE
Migration to new Cloud API

### DIFF
--- a/source/TwainDirect.App/TwainDirect.App.csproj
+++ b/source/TwainDirect.App/TwainDirect.App.csproj
@@ -214,7 +214,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="HazyBits.Twain.Cloud.Forms">
-      <Version>1.0.37</Version>
+      <Version>1.0.42</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="MsBuildAL1073WarningWorkaround.targets" />

--- a/source/TwainDirect.App/app.config
+++ b/source/TwainDirect.App/app.config
@@ -3,7 +3,7 @@
   <appSettings>
     <add key="LocalizedPerfCounter" value="false" />
     <add key="CloudName" value="HazyBits"/>
-    <add key="CloudApiRoot" value="https://api-twain.hazybits.com/dev"/>
+    <add key="CloudApiRoot" value="https://twain.hazybits.com/api"/>
     <add key="CloudManager" value="https://twain.hazybits.com"/>
     <add key="CloudFolderName" value="hazybits"/>
     <add key="CloudUseHttps" value="yes"/>

--- a/source/TwainDirect.Scanner/TwainDirect.Scanner.csproj
+++ b/source/TwainDirect.Scanner/TwainDirect.Scanner.csproj
@@ -192,7 +192,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="HazyBits.Twain.Cloud.Forms">
-      <Version>1.0.39</Version>
+      <Version>1.0.42</Version>
     </PackageReference>
     <PackageReference Include="SQLite.CodeFirst">
       <Version>1.5.1.25</Version>

--- a/source/TwainDirect.Scanner/app.config
+++ b/source/TwainDirect.Scanner/app.config
@@ -6,7 +6,7 @@
   <appSettings>
     <add key="LocalizedPerfCounter" value="false" />
     <add key="CloudName" value="HazyBits"/>
-    <add key="CloudApiRoot" value="https://api-twain.hazybits.com/dev"/>
+    <add key="CloudApiRoot" value="https://twain.hazybits.com/api"/>
     <add key="CloudManager" value="https://twain.hazybits.com"/>
     <add key="CloudFolderName" value="hazybits"/>
     <add key="CloudUseHttps" value="yes"/>

--- a/source/TwainDirect.Support/TwainDirect.Support.csproj
+++ b/source/TwainDirect.Support/TwainDirect.Support.csproj
@@ -106,7 +106,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="HazyBits.Twain.Cloud">
-      <Version>1.0.39</Version>
+      <Version>1.0.42</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>6.0.8</Version>


### PR DESCRIPTION
@mlmcl62 Take a look at this, please. With this small change existing apps can communication with updated Cloud APIs (binary payloads, etc.) in the same way as with local twain-cloud-express.

I'm still working on authentication but wanted to let you know that functional part of the APIs is ready to play with.

'privet' prefix is still supported by Cloud (along with new APIs without the prefix) since the tools have not been updated yet. Are you going to work on the necessary changes?
