### PR TITLE
typos in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ To build the project, you usually need to perform the following steps:
  - Build PDF Raster solution (/source/pdfraster/pdfraster.sln)
   
  - [optional] [Download nuget](https://dist.nuget.org/index.html) (if you don't have it already)
- - Install [Wix](http://wixtoolset.org/) to add installer project types in Visual Studio
- - Install [BouncyCastle](http://https://www.bouncycastle.org//) to add support for Self-Certification
+ - Install [Wix](https://wixtoolset.org/) to add installer project types in Visual Studio
+ - Install [BouncyCastle](https://www.bouncycastle.org//) to add support for Self-Certification
  - Restore packages by running ```nuget.exe restore TwainDirect.sln```
  
  - Build PDF/raster solution (/source/pdfraster/pdfraster.sln)


### PR DESCRIPTION
Some of the URLs were misspelled. When clicking on BouncyCastle link, a different, totally unrelated website was opened.